### PR TITLE
Add a hasSpawned boolean and the methods for accessing it. Add test cases.

### DIFF
--- a/tomb.go
+++ b/tomb.go
@@ -1,10 +1,10 @@
 // Copyright (c) 2011 - Gustavo Niemeyer <gustavo@niemeyer.net>
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
+//
 //     * Redistributions of source code must retain the above copyright notice,
 //       this list of conditions and the following disclaimer.
 //     * Redistributions in binary form must reproduce the above copyright notice,
@@ -13,7 +13,7 @@
 //     * Neither the name of the copyright holder nor the names of its
 //       contributors may be used to endorse or promote products derived from
 //       this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,7 +32,7 @@
 // goroutine via its Go method, and then any tracked goroutine may call
 // the Go method again to create additional tracked goroutines at
 // any point.
-// 
+//
 // If any of the tracked goroutines returns a non-nil error, or the
 // Kill or Killf method is called by any goroutine in the system (tracked
 // or not), the tomb Err is set, Alive is set to false, and the Dying
@@ -73,16 +73,17 @@ import (
 //
 // See the package documentation for details.
 type Tomb struct {
-	m      sync.Mutex
-	alive  int
-	dying  chan struct{}
-	dead   chan struct{}
-	reason error
+	m          sync.Mutex
+	alive      int
+	dying      chan struct{}
+	dead       chan struct{}
+	reason     error
+	hasSpawned bool
 }
 
 var (
 	ErrStillAlive = errors.New("tomb: still alive")
-	ErrDying = errors.New("tomb: dying")
+	ErrDying      = errors.New("tomb: dying")
 )
 
 func (t *Tomb) init() {
@@ -137,6 +138,7 @@ func (t *Tomb) Wait() error {
 // causes a runtime panic. For that reason, calling the Go
 // method a second time out of a tracked goroutine is unsafe.
 func (t *Tomb) Go(f func() error) {
+	t.hasSpawned = true
 	t.init()
 	t.m.Lock()
 	defer t.m.Unlock()
@@ -220,4 +222,19 @@ func (t *Tomb) Err() (reason error) {
 // Alive returns true if the tomb is not in a dying or dead state.
 func (t *Tomb) Alive() bool {
 	return t.Err() == ErrStillAlive
+}
+
+// HasSpawned returns true if the tomb has spawned a routine.
+func (t *Tomb) HasSpawned() bool {
+	return t.hasSpawned
+}
+
+// TrackedAlive returns true if the tomb has spawned in the past
+// and is not in a dead or dying state.
+func (t *Tomb) TrackedAlive() bool {
+	if t.hasSpawned {
+		return t.Alive()
+	} else {
+		return false
+	}
 }


### PR DESCRIPTION
Thanks for this useful package!

This pull request adds a hasSpawned flag which returns true if the tomb has spawned before. In some pool-like patterns, it is nice to be able to evaluate if a tomb has any live tracked goroutines. This change does not affect any existing interfaces, it exclusively adds two new ones: HasSpawned(), which returns if the tomb has spawned before, and TrackedAlive(), which returns if the tomb is alive and has spawned in the past, which should indicate that there are running tracked goroutines.

Apologies in advance for the whitespace changes, I ran gofmt on the code to get my formatting in line with yours and it made a few changes to existing code.

I'd love to discuss this and I'm open to any changes or suggestions you might have.
