### PR TITLE
Ensure Dead() doesn't block when no goroutines are spawned

### DIFF
--- a/tomb_test.go
+++ b/tomb_test.go
@@ -145,6 +145,13 @@ func TestKillErrStillAlivePanic(t *testing.T) {
 	tb.Kill(tomb.ErrStillAlive)
 }
 
+func TestWaitNoGoroutine(t *testing.T) {
+	tb := &tomb.Tomb{}
+	tb.Kill(nil)
+	tb.Wait()
+	checkState(t, tb, true, true, nil)
+}
+
 func checkState(t *testing.T, tb *tomb.Tomb, wantDying, wantDead bool, wantErr error) {
 	select {
 	case <-tb.Dying():


### PR DESCRIPTION
This is done by closing the dead channel and creating a new one on the
first spawned goroutine. There are several problems with this
approach:

 1. Tests are expecting `Dead()` to block. I didn't "correct" the
    tests as it seems to be a strong assumption.

 2. People may expect `Dead()` to block even without any
    goroutine. One may start an unmanaged goroutine using `Dead()` and
    then only spawn goroutines with the tomb. Before this change, no
    problem. After this change, the unmanaged goroutine will not be
    blocked by `Dead()`.

Related to #17.

So, in conclusion, there is no good way around that. Maybe just document that at least a goroutine is needed to get the expected behavior. I am making this PR as a documentation for my tentative. Feel free to close it.