### PR TITLE
Fix data race in WithContext with cancelled parent

### DIFF
--- a/context.go
+++ b/context.go
@@ -13,6 +13,9 @@ import (
 func WithContext(parent context.Context) (*Tomb, context.Context) {
 	var t Tomb
 	t.init()
+	t.parent = parent
+	child, cancel := context.WithCancel(parent)
+	t.addChild(parent, child, cancel)
 	if parent.Done() != nil {
 		go func() {
 			select {
@@ -22,9 +25,6 @@ func WithContext(parent context.Context) (*Tomb, context.Context) {
 			}
 		}()
 	}
-	t.parent = parent
-	child, cancel := context.WithCancel(parent)
-	t.addChild(parent, child, cancel)
 	return &t, child
 }
 

--- a/context16.go
+++ b/context16.go
@@ -13,6 +13,9 @@ import (
 func WithContext(parent context.Context) (*Tomb, context.Context) {
 	var t Tomb
 	t.init()
+	t.parent = parent
+	child, cancel := context.WithCancel(parent)
+	t.addChild(parent, child, cancel)
 	if parent.Done() != nil {
 		go func() {
 			select {
@@ -22,9 +25,6 @@ func WithContext(parent context.Context) (*Tomb, context.Context) {
 			}
 		}()
 	}
-	t.parent = parent
-	child, cancel := context.WithCancel(parent)
-	t.addChild(parent, child, cancel)
 	return &t, child
 }
 


### PR DESCRIPTION
If the parent context is already cancelled, or cancelled before WithContext returns, there is a data race that can happen between the goroutine that is spawned to detect when the parent context is cancelled or the tomb is dying, which calls Kill() and the code in WithContext that updates the children.

This change fixes the race by not kicking off the goroutine that waits for parent cancellation until after the rest of the initialization has been completed.